### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 A simple echo MCP (Model Context Protocol) Server with a simple `echo_tool` for testing MCP Clients.
 It is also great as a template for new MCP Servers.
 
+<a href="https://glama.ai/mcp/servers/@piebro/echo-mcp-server-for-testing">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@piebro/echo-mcp-server-for-testing/badge" alt="Echo Server MCP server" />
+</a>
+
 ## Usage
 
 Install [uv](https://docs.astral.sh/uv/) and add the server to an MCP config using `uvx`:


### PR DESCRIPTION
This PR adds a badge for the [Echo MCP Server](https://glama.ai/mcp/servers/@piebro/echo-mcp-server-for-testing) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@piebro/echo-mcp-server-for-testing">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@piebro/echo-mcp-server-for-testing/badge" alt="Echo Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.